### PR TITLE
Removing /edge from default-provider

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,7 +29,7 @@ plugs:
   graphics-core20:
     interface: content
     target: $SNAP/graphics
-    default-provider: nvidia-core20/edge
+    default-provider: nvidia-core20
 
 apps:
   bandwidthTest:


### PR DESCRIPTION
This is preventing the autoload of nvidia-core20 snap and causes failure when bulding images including nvidia snaps